### PR TITLE
Fix for issue #20

### DIFF
--- a/src/Parsers/TexFile.cpp
+++ b/src/Parsers/TexFile.cpp
@@ -40,5 +40,9 @@ bool TexFile::LoadFromDisk(boost::filesystem::path path)
 
 std::wstring &TexFile::GetString(TextSection sec, uint16_t index)
 {
-    return strings.at(sec)[index];
+    if(index < strings.at(sec).size())
+        return strings.at(sec)[index];
+
+    Logger::warning(PARSERS) << "Trying to get string " << index << " from section " << sec << ", that only contain " << (strings.at(sec).size()-1) << " of these." << std::endl;
+    return dummy_text;
 }

--- a/src/Parsers/TexFile.h
+++ b/src/Parsers/TexFile.h
@@ -23,6 +23,7 @@ namespace Sourcehold {
             std::wstring &GetString(TextSection sec, uint16_t index);
         protected:
             std::map<TextSection, std::vector<std::wstring>> strings;
+            std::wstring dummy_text = L"Text not found";
         };
     }
 }

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -128,12 +128,15 @@ UIState Startup::Begin()
               }
               break;
             case STARTUP_MULTIPLAYER_INFO:
-              font->SetAlphaMod(alpha);
-              RenderText(
-                         startupStr,
-                         (GetWidth() / 2) - (dim.first / 2),
-                         (GetHeight() / 2) - (dim.second / 2),
-                         FONT_LARGE, false, 0.7);
+              if(ed != STRONGHOLD_CLASSIC)
+              {
+                font->SetAlphaMod(alpha);
+                RenderText(
+                           startupStr,
+                           (GetWidth() / 2) - (dim.first / 2),
+                           (GetHeight() / 2) - (dim.second / 2),
+                           FONT_LARGE, false, 0.7);
+              }
               break;
             case STARTUP_INTRO:
               font->SetAlphaMod(255);


### PR DESCRIPTION
Running on Linux I found the same memory problem that issue #20 . But the debugger shows that the problem was in the previous line of what @nitramr pointed ([this one](https://github.com/sourcehold/Sourcehold/blob/61c0ac69583c8fa046c654a66c20ab8f94b8e2d0/src/Startup.cpp#L37)).

Note that my changes on "Startup.cpp" are far from being elegant as I didn't wanted to introduce so much changes on the `switch` there. Also, the new `Logger::warning(PARSERS)` is somewhat unnecessary.
___
- A memory issue as the game was trying to retrieve the text "Gameplay during online..." that didn't exist in the 2001 version
- This fix skips that text at the startup and will print a warning
- Also for similar issues in the future, a dummy text is returned