### PR TITLE
Improvements in IDE projects generation by Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,17 +11,28 @@ add_subdirectory(src)
 
 # TODO(seidl):
 # still some modules hidden here..
-add_executable(${PROJECT_NAME}
+set(SOURCE_FILES 
+  src/Assets.h
   src/Assets.cpp
+  src/Building.h
   src/Building.cpp
   src/Game.cpp
+  src/GameManager.h
   src/GameManager.cpp
+  src/GameMap.h
   src/GameMap.cpp
+  src/Startup.h
   src/Startup.cpp
+  src/World.h
   src/World.cpp
 )
 
-target_include_directories(${PROJECT_NAME} PRIVATE src/)
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+source_group("Source Files" FILES ${SOURCE_FILES})
+
+target_include_directories(${PROJECT_NAME}
+  PRIVATE src/
+)
 
 if(TARGET_OS_MAC_OS OR TARGET_OS_IOS)
   target_link_libraries(${PROJECT_NAME}

--- a/apple/CMakeLists.txt
+++ b/apple/CMakeLists.txt
@@ -1,9 +1,17 @@
 if(TARGET_OS_MAC_OS OR TARGET_OS_IOS)
 # AppleUtils
-  add_library(AppleUtils Common/SHPathUtils.m)
+  set(APPLE_UTILS_SOURCE_FILES 
+    Common/SHPathUtils.h
+    Common/SHPathUtils.m
+  )
+
+  add_library(AppleUtils ${APPLE_UTILS_SOURCE_FILES})
+  source_group("Source Files" FILES ${APPLE_UTILS_SOURCE_FILES})
+
   target_include_directories(AppleUtils
     PUBLIC ${CMAKE_SOURCE_DIR}/apple
   )
+
   target_link_libraries(AppleUtils
     PRIVATE "-framework Foundation"
     PRIVATE ProjectOptions

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,8 +1,16 @@
 # Thirdparty
 # blast
-add_library(blast ${CMAKE_SOURCE_DIR}/thirdparty/blast/blast.c)
+set(BLAST_SOURCE_DIR ${CMAKE_SOURCE_DIR}/thirdparty/blast)
+set(BLAST_SOURCE_FILES
+  ${BLAST_SOURCE_DIR}/blast.h
+  ${BLAST_SOURCE_DIR}/blast.c
+)
+
+add_library(blast ${BLAST_SOURCE_FILES})
+source_group("Source Files" FILES ${BLAST_SOURCE_FILES})
+
 target_include_directories(blast
-  PUBLIC ${CMAKE_SOURCE_DIR}/thirdparty/blast
+  PUBLIC ${BLAST_SOURCE_DIR}
 )
 
 # cxxopts

--- a/src/Audio/CMakeLists.txt
+++ b/src/Audio/CMakeLists.txt
@@ -1,8 +1,14 @@
-add_library(Audio 
+set(AUDIO_SOURCE_FILES 
+  Audio.h
   Audio.cpp
+  Effect.h
   Effect.cpp
+  Song.h
   Song.cpp
 )
+
+add_library(Audio ${AUDIO_SOURCE_FILES})
+source_group("Source Files" FILES ${AUDIO_SOURCE_FILES})
 
 # TODO(seidl):
 # change headers to correct paths

--- a/src/ECS/CMakeLists.txt
+++ b/src/ECS/CMakeLists.txt
@@ -1,11 +1,21 @@
-add_library(ECS
+set(ECS_SOURCE_FILES
+  Component/Component.h
+  ECS.h
   ECS.cpp
+  Manager.h
   Manager.cpp
+  System/BasicSystem.h
   System/BasicSystem.cpp
+  System/RenderSystem.h
   System/RenderSystem.cpp
+  System/AnimationFrameSystem.h
   System/AnimationFrameSystem.cpp
+  System/TestTeleportingDeerSystem.h
   System/TestTeleportingDeerSystem.cpp
 )
+
+add_library(ECS ${ECS_SOURCE_FILES})
+source_group("Source Files" FILES ${ECS_SOURCE_FILES})
 
 target_include_directories(ECS PRIVATE ../)
 target_link_libraries(ECS 

--- a/src/Events/CMakeLists.txt
+++ b/src/Events/CMakeLists.txt
@@ -1,8 +1,16 @@
-add_library(Events 
+set(EVENTS_SOURCE_FILES
+  Event.h
+  EventHandler.h
   EventHandler.cpp
+  Keyboard.h
   Keyboard.cpp
+  Mouse.h
   Mouse.cpp
+  Touch.h
 )
+
+add_library(Events ${EVENTS_SOURCE_FILES})
+source_group("Source Files" FILES ${EVENTS_SOURCE_FILES})
 
 target_include_directories(Events PRIVATE ../)
 target_link_libraries(Events

--- a/src/FFMPEG/CMakeLists.txt
+++ b/src/FFMPEG/CMakeLists.txt
@@ -1,7 +1,13 @@
-add_library(FFmpegUtil
+set(FFMPEG_UTIL_SOURCE_FILES
+  FFmpegUtil.h
   FFmpegUtil.cpp
-  )
+)
+
+add_library(FFmpegUtil ${FFMPEG_UTIL_SOURCE_FILES})
+source_group("Source Files" FILES ${FFMPEG_UTIL_SOURCE_FILES})
+
 target_include_directories(FFmpegUtil PRIVATE ../)
+
 target_link_libraries(FFmpegUtil
   PRIVATE ProjectOptions
   PRIVATE System

--- a/src/GUI/CMakeLists.txt
+++ b/src/GUI/CMakeLists.txt
@@ -1,17 +1,40 @@
-add_library(GUI
+set(GUI_SOURCE_FILES
+  Credits.h
   Credits.cpp
+  Dialog.h
   Dialog.cpp
+  Ingame.h
   Ingame.cpp
+  Layout.h
   Layout.cpp
+  MainMenu.h
   MainMenu.cpp
+  MenuUtils.h
   MenuUtils.cpp
+  NarrScreen.h
   NarrScreen.cpp
-  Widgets/Button.cpp
-  Widgets/Container.cpp
-  Widgets/LineEdit.cpp
-  Widgets/StaticElement.cpp
-  Widgets/Table.cpp
+  UIState.h
 )
+set(GUI_WIDGETS_SOURCE_FILES
+  Widgets/Button.h
+  Widgets/Button.cpp
+  Widgets/Container.h
+  Widgets/Container.cpp
+  Widgets/LineEdit.h
+  Widgets/LineEdit.cpp
+  Widgets/StaticElement.h
+  Widgets/StaticElement.cpp
+  Widgets/Table.h
+  Widgets/Table.cpp
+  Widgets/Widget.h
+)
+
+add_library(GUI
+  ${GUI_SOURCE_FILES}
+  ${GUI_WIDGETS_SOURCE_FILES}
+)
+source_group("Source Files" FILES ${GUI_SOURCE_FILES})
+source_group("Source Files\\Widgets" FILES ${GUI_WIDGETS_SOURCE_FILES})
 
 target_include_directories(GUI PRIVATE ../)
 target_link_libraries(GUI

--- a/src/Parsers/CMakeLists.txt
+++ b/src/Parsers/CMakeLists.txt
@@ -1,15 +1,29 @@
-add_library(Parsers 
+set(PARSERS_SOURCE_FILES
+  AniFile.h
   AniFile.cpp
+  CfgFile.h
   CfgFile.cpp
+  Gm1File.h
   Gm1File.cpp
+  HlpFile.h
   HlpFile.cpp
+  MapFile.h
   MapFile.cpp
+  MlbFile.h
   MlbFile.cpp
+  Parser.h
   Parser.cpp
+  Riff.h
+  TexFile.h
   TexFile.cpp
+  TgxFile.h
   TgxFile.cpp
+  VolumeTxt.h
   VolumeTxt.cpp
 )
+
+add_library(Parsers ${PARSERS_SOURCE_FILES})
+source_group("Source Files" FILES ${PARSERS_SOURCE_FILES})
 
 target_include_directories(Parsers PRIVATE ../)
 target_link_libraries(Parsers 

--- a/src/Rendering/CMakeLists.txt
+++ b/src/Rendering/CMakeLists.txt
@@ -1,14 +1,27 @@
-add_library(Rendering
+set(RENDERING_SOURCE_FILES
+  BinkVideo.h
   BinkVideo.cpp
+  Camera.h
   Camera.cpp
+  Display.h
   Display.cpp
+  Font.h
   Font.cpp
+  Renderer.h
   Renderer.cpp
+  Shapes.h
+  Surface.h
   Surface.cpp
-  TextureAtlas.cpp
+  Texture.h
   Texture.cpp
+  TextureAtlas.h
+  TextureAtlas.cpp
+  Tileset.h
   Tileset.cpp
 )
+
+add_library(Rendering ${RENDERING_SOURCE_FILES})
+source_group("Source Files" FILES ${RENDERING_SOURCE_FILES})
 
 target_include_directories(Rendering 
   PRIVATE ../

--- a/src/System/CMakeLists.txt
+++ b/src/System/CMakeLists.txt
@@ -1,8 +1,18 @@
-add_library(System
+set(SYSTEM_SOURCE_FILES
+  Config.h
+  filesystem.h
+  FileUtil.h
   FileUtil.cpp
+  Logger.h
   Logger.cpp
+  ModCampaign.h
   ModCampaign.cpp
+  System.h
 )
+
+add_library(System ${SYSTEM_SOURCE_FILES})
+source_group("Source Files" FILES ${SYSTEM_SOURCE_FILES})
+
 target_include_directories(System PRIVATE ../)
 target_link_libraries(System 
   PRIVATE ProjectOptions


### PR DESCRIPTION
Add header files to sources to be able to access them via generated IDE projects (Xcode in particular). Group sources into custom groups to avoid default cmake grouping which puts .h and .cpp files to separate groups.